### PR TITLE
Implement Send and Clone for Sid

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -94,6 +94,7 @@ pub enum State {
 /// decay, in effect further dividing the clock to the envelope counter.
 /// The period of this counter is set to 1, 2, 4, 8, 16, 30 at the envelope
 /// counter values 255, 93, 54, 26, 14, 6, respectively.
+#[derive(Clone, Copy)]
 pub struct EnvelopeGenerator {
     // Configuration
     attack: u8,

--- a/src/external_filter.rs
+++ b/src/external_filter.rs
@@ -28,6 +28,7 @@ const W0_HP: i32 = 105;
 /// additional low-pass and high-pass 3dB-frequencies in the order of hundreds
 /// of kHz. This calls for a sampling frequency of several MHz, which is far
 /// too high for practical use.
+#[derive(Clone, Copy)]
 pub struct ExternalFilter {
     // Configuration
     enabled: bool,

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -122,6 +122,7 @@ static FO_POINTS_8580: [(i32, i32); 19] = [
 /// into its region of quasi-linear operation using a feedback resistor from
 /// input to output, a MOS inverter can be made to act like an op-amp for
 /// small signals centered around the switching threshold.
+#[derive(Clone, Copy)]
 pub struct Filter {
     // Configuration
     enabled: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 // Portions (c) 2004 Dag Lem <resid@nimrod.no>
 // Licensed under the GPLv3. See LICENSE file in the project root for full license text.
 
-#![feature(array_methods)]
 #![no_std]
 
 #[cfg(not(feature = "std"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 // Portions (c) 2004 Dag Lem <resid@nimrod.no>
 // Licensed under the GPLv3. See LICENSE file in the project root for full license text.
 
+#![feature(array_methods)]
 #![no_std]
 
 #[cfg(not(feature = "std"))]

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -38,6 +38,7 @@ pub enum SamplingMethod {
     ResampleFast,
 }
 
+#[derive(Clone)]
 pub struct Sampler {
     // Dependencies
     pub synth: Synth,

--- a/src/sid.rs
+++ b/src/sid.rs
@@ -60,6 +60,7 @@ pub struct State {
     pub rate_counter_period: [u16; 3],
 }
 
+#[derive(Clone)]
 pub struct Sid {
     // Functional Units
     sampler: Sampler,
@@ -165,7 +166,7 @@ impl Sid {
         match reg {
             reg::POTX => 0xff,
             reg::POTY => 0xff,
-            reg::OSC3 => self.sampler.synth.voices[2].wave.borrow().read_osc(),
+            reg::OSC3 => self.sampler.synth.syncable_voice(2).wave().read_osc(),
             reg::ENV3 => self.sampler.synth.voices[2].envelope.read_env(),
             _ => self.bus_value,
         }
@@ -176,28 +177,16 @@ impl Sid {
         self.bus_value_ttl = 0x2000;
         match reg {
             reg::FREQLO1 => {
-                self.sampler.synth.voices[0]
-                    .wave
-                    .borrow_mut()
-                    .set_frequency_lo(value);
+                self.sampler.synth.voices[0].wave.set_frequency_lo(value);
             }
             reg::FREQHI1 => {
-                self.sampler.synth.voices[0]
-                    .wave
-                    .borrow_mut()
-                    .set_frequency_hi(value);
+                self.sampler.synth.voices[0].wave.set_frequency_hi(value);
             }
             reg::PWLO1 => {
-                self.sampler.synth.voices[0]
-                    .wave
-                    .borrow_mut()
-                    .set_pulse_width_lo(value);
+                self.sampler.synth.voices[0].wave.set_pulse_width_lo(value);
             }
             reg::PWHI1 => {
-                self.sampler.synth.voices[0]
-                    .wave
-                    .borrow_mut()
-                    .set_pulse_width_hi(value);
+                self.sampler.synth.voices[0].wave.set_pulse_width_hi(value);
             }
             reg::CR1 => {
                 self.sampler.synth.voices[0].set_control(value);
@@ -213,28 +202,16 @@ impl Sid {
                     .set_sustain_release(value);
             }
             reg::FREQLO2 => {
-                self.sampler.synth.voices[1]
-                    .wave
-                    .borrow_mut()
-                    .set_frequency_lo(value);
+                self.sampler.synth.voices[1].wave.set_frequency_lo(value);
             }
             reg::FREQHI2 => {
-                self.sampler.synth.voices[1]
-                    .wave
-                    .borrow_mut()
-                    .set_frequency_hi(value);
+                self.sampler.synth.voices[1].wave.set_frequency_hi(value);
             }
             reg::PWLO2 => {
-                self.sampler.synth.voices[1]
-                    .wave
-                    .borrow_mut()
-                    .set_pulse_width_lo(value);
+                self.sampler.synth.voices[1].wave.set_pulse_width_lo(value);
             }
             reg::PWHI2 => {
-                self.sampler.synth.voices[1]
-                    .wave
-                    .borrow_mut()
-                    .set_pulse_width_hi(value);
+                self.sampler.synth.voices[1].wave.set_pulse_width_hi(value);
             }
             reg::CR2 => {
                 self.sampler.synth.voices[1].set_control(value);
@@ -250,28 +227,16 @@ impl Sid {
                     .set_sustain_release(value);
             }
             reg::FREQLO3 => {
-                self.sampler.synth.voices[2]
-                    .wave
-                    .borrow_mut()
-                    .set_frequency_lo(value);
+                self.sampler.synth.voices[2].wave.set_frequency_lo(value);
             }
             reg::FREQHI3 => {
-                self.sampler.synth.voices[2]
-                    .wave
-                    .borrow_mut()
-                    .set_frequency_hi(value);
+                self.sampler.synth.voices[2].wave.set_frequency_hi(value);
             }
             reg::PWLO3 => {
-                self.sampler.synth.voices[2]
-                    .wave
-                    .borrow_mut()
-                    .set_pulse_width_lo(value);
+                self.sampler.synth.voices[2].wave.set_pulse_width_lo(value);
             }
             reg::PWHI3 => {
-                self.sampler.synth.voices[2]
-                    .wave
-                    .borrow_mut()
-                    .set_pulse_width_hi(value);
+                self.sampler.synth.voices[2].wave.set_pulse_width_hi(value);
             }
             reg::CR3 => {
                 self.sampler.synth.voices[2].set_control(value);
@@ -322,7 +287,7 @@ impl Sid {
         };
         for i in 0..3 {
             let j = i * 7;
-            let wave = self.sampler.synth.voices[i].wave.borrow();
+            let wave = &self.sampler.synth.voices[i].wave;
             let envelope = &self.sampler.synth.voices[i].envelope;
             state.sid_register[j] = wave.get_frequency_lo();
             state.sid_register[j + 1] = wave.get_frequency_hi();
@@ -347,7 +312,7 @@ impl Sid {
         state.bus_value_ttl = self.bus_value_ttl;
         state.ext_in = self.sampler.synth.ext_in;
         for i in 0..3 {
-            let wave = self.sampler.synth.voices[i].wave.borrow();
+            let wave = &self.sampler.synth.voices[i].wave;
             let envelope = &self.sampler.synth.voices[i].envelope;
             state.accumulator[i] = wave.get_acc();
             state.shift_register[i] = wave.get_shift();
@@ -371,8 +336,8 @@ impl Sid {
         self.sampler.synth.ext_in = state.ext_in;
         for i in 0..3 {
             let envelope = &mut self.sampler.synth.voices[i].envelope;
-            self.sampler.synth.voices[i].wave.borrow_mut().acc = state.accumulator[i];
-            self.sampler.synth.voices[i].wave.borrow_mut().shift = state.shift_register[i];
+            self.sampler.synth.voices[i].wave.acc = state.accumulator[i];
+            self.sampler.synth.voices[i].wave.shift = state.shift_register[i];
             envelope.state = match state.envelope_state[i] {
                 0 => EnvState::Attack,
                 1 => EnvState::DecaySustain,

--- a/src/synth.rs
+++ b/src/synth.rs
@@ -34,7 +34,8 @@ impl Synth {
     }
 
     pub fn syncable_voice(&self, i: usize) -> Syncable<&'_ Voice> {
-        let mut voices_ref = self.voices.each_ref();
+        let [a, b, c] = &self.voices;
+        let mut voices_ref = [a, b, c];
         voices_ref.rotate_left(i);
         let [main, sync_dest, sync_source] = voices_ref;
         Syncable {
@@ -45,7 +46,8 @@ impl Synth {
     }
 
     pub fn syncable_voice_mut(&mut self, i: usize) -> Syncable<&'_ mut Voice> {
-        let mut voices_mut = self.voices.each_mut();
+        let [a, b, c] = &mut self.voices;
+        let mut voices_mut = [a, b, c];
         voices_mut.rotate_left(i);
         let [main, sync_dest, sync_source] = voices_mut;
         Syncable {

--- a/src/synth.rs
+++ b/src/synth.rs
@@ -8,12 +8,14 @@
 use super::external_filter::ExternalFilter;
 use super::filter::Filter;
 use super::voice::Voice;
+use super::wave::{Syncable, WaveformGenerator};
 use super::ChipModel;
 
 const OUTPUT_RANGE: u32 = 1 << 16;
 const OUTPUT_HALF: i32 = (OUTPUT_RANGE >> 1) as i32;
 const SAMPLES_PER_OUTPUT: u32 = (((4095 * 255) >> 7) * 3 * 15 * 2 / OUTPUT_RANGE);
 
+#[derive(Clone, Copy)]
 pub struct Synth {
     pub ext_filter: ExternalFilter,
     pub filter: Filter,
@@ -23,17 +25,33 @@ pub struct Synth {
 
 impl Synth {
     pub fn new(chip_model: ChipModel) -> Self {
-        let mut voice1 = Voice::new(chip_model);
-        let mut voice2 = Voice::new(chip_model);
-        let mut voice3 = Voice::new(chip_model);
-        voice1.set_sync_source(&mut voice3);
-        voice2.set_sync_source(&mut voice1);
-        voice3.set_sync_source(&mut voice2);
         Synth {
             ext_filter: ExternalFilter::new(chip_model),
             filter: Filter::new(chip_model),
-            voices: [voice1, voice2, voice3],
+            voices: [Voice::new(chip_model); 3],
             ext_in: 0,
+        }
+    }
+
+    pub fn syncable_voice(&self, i: usize) -> Syncable<&'_ Voice> {
+        let mut voices_ref = self.voices.each_ref();
+        voices_ref.rotate_left(i);
+        let [main, sync_dest, sync_source] = voices_ref;
+        Syncable {
+            main,
+            sync_dest,
+            sync_source,
+        }
+    }
+
+    pub fn syncable_voice_mut(&mut self, i: usize) -> Syncable<&'_ mut Voice> {
+        let mut voices_mut = self.voices.each_mut();
+        voices_mut.rotate_left(i);
+        let [main, sync_dest, sync_source] = voices_mut;
+        Syncable {
+            main,
+            sync_dest,
+            sync_source,
         }
     }
 
@@ -44,17 +62,17 @@ impl Synth {
         }
         // Clock oscillators.
         for i in 0..3 {
-            self.voices[i].wave.borrow_mut().clock();
+            self.voices[i].wave.clock();
         }
         // Synchronize oscillators.
         for i in 0..3 {
-            self.voices[i].wave.borrow_mut().synchronize();
+            self.syncable_voice_mut(i).wave().synchronize();
         }
         // Clock filter.
         self.filter.clock(
-            self.voices[0].output(),
-            self.voices[1].output(),
-            self.voices[2].output(),
+            self.syncable_voice(0).output(),
+            self.syncable_voice(1).output(),
+            self.syncable_voice(2).output(),
             self.ext_in,
         );
         // Clock external filter.
@@ -73,14 +91,14 @@ impl Synth {
             // correctly.
             let mut delta_min = delta_osc;
             for i in 0..3 {
-                let wave = &self.voices[i].wave;
+                let wave = self.syncable_voice(i).wave();
                 // It is only necessary to clock on the MSB of an oscillator that is
                 // a sync source and has freq != 0.
-                if !(wave.borrow().get_sync_dest_sync() && wave.borrow().get_frequency() != 0) {
+                if !(wave.sync_dest.get_sync() && wave.main.get_frequency() != 0) {
                     continue;
                 }
-                let freq = wave.borrow().get_frequency() as u32;
-                let acc = wave.borrow().get_acc();
+                let freq = wave.main.get_frequency() as u32;
+                let acc = wave.main.get_acc();
                 // Clock on MSB off if MSB is on, clock on MSB on if MSB is off.
                 let delta_acc = if acc & 0x0080_0000 != 0 {
                     0x0100_0000 - acc
@@ -97,20 +115,20 @@ impl Synth {
             }
             // Clock oscillators.
             for i in 0..3 {
-                self.voices[i].wave.borrow_mut().clock_delta(delta_min);
+                self.voices[i].wave.clock_delta(delta_min);
             }
             // Synchronize oscillators.
             for i in 0..3 {
-                self.voices[i].wave.borrow_mut().synchronize();
+                self.syncable_voice_mut(i).wave().synchronize();
             }
             delta_osc -= delta_min;
         }
         // Clock filter.
         self.filter.clock_delta(
             delta,
-            self.voices[0].output(),
-            self.voices[1].output(),
-            self.voices[2].output(),
+            self.syncable_voice(0).output(),
+            self.syncable_voice(1).output(),
+            self.syncable_voice(2).output(),
             self.ext_in,
         );
         // Clock external filter.

--- a/tests/wave_test.rs
+++ b/tests/wave_test.rs
@@ -17,7 +17,7 @@ fn waveform_1() {
     setup(&mut wave, 1, 32000, 100);
     for i in 0..500 {
         wave.clock();
-        assert_eq!(wave.output(), data::wave_output::RESID_WAVE1_OUTPUT[i]);
+        assert_eq!(wave.output(None), data::wave_output::RESID_WAVE1_OUTPUT[i]);
     }
 }
 
@@ -27,7 +27,7 @@ fn waveform_2() {
     setup(&mut wave, 2, 16000, 100);
     for i in 0..500 {
         wave.clock();
-        assert_eq!(wave.output(), data::wave_output::RESID_WAVE2_OUTPUT[i]);
+        assert_eq!(wave.output(None), data::wave_output::RESID_WAVE2_OUTPUT[i]);
     }
 }
 
@@ -37,7 +37,7 @@ fn waveform_3() {
     setup(&mut wave, 3, 32000, 100);
     for i in 0..500 {
         wave.clock();
-        assert_eq!(wave.output(), data::wave_output::RESID_WAVE3_OUTPUT[i]);
+        assert_eq!(wave.output(None), data::wave_output::RESID_WAVE3_OUTPUT[i]);
     }
 }
 
@@ -47,7 +47,7 @@ fn waveform_4() {
     setup(&mut wave, 4, 16000, 1000);
     for i in 0..1500 {
         wave.clock();
-        assert_eq!(wave.output(), data::wave_output::RESID_WAVE4_OUTPUT[i]);
+        assert_eq!(wave.output(None), data::wave_output::RESID_WAVE4_OUTPUT[i]);
     }
 }
 
@@ -57,7 +57,7 @@ fn waveform_5() {
     setup(&mut wave, 5, 16000, 1000);
     for i in 0..1500 {
         wave.clock();
-        assert_eq!(wave.output(), data::wave_output::RESID_WAVE5_OUTPUT[i]);
+        assert_eq!(wave.output(None), data::wave_output::RESID_WAVE5_OUTPUT[i]);
     }
 }
 
@@ -67,7 +67,7 @@ fn waveform_6() {
     setup(&mut wave, 6, 16000, 1000);
     for i in 0..1500 {
         wave.clock();
-        assert_eq!(wave.output(), data::wave_output::RESID_WAVE6_OUTPUT[i]);
+        assert_eq!(wave.output(None), data::wave_output::RESID_WAVE6_OUTPUT[i]);
     }
 }
 
@@ -77,7 +77,7 @@ fn waveform_7() {
     setup(&mut wave, 7, 16000, 1000);
     for i in 0..1500 {
         wave.clock();
-        assert_eq!(wave.output(), data::wave_output::RESID_WAVE7_OUTPUT[i]);
+        assert_eq!(wave.output(None), data::wave_output::RESID_WAVE7_OUTPUT[i]);
     }
 }
 
@@ -87,7 +87,7 @@ fn waveform_8() {
     setup(&mut wave, 8, 16000, 1000);
     for i in 0..1500 {
         wave.clock();
-        assert_eq!(wave.output(), data::wave_output::RESID_WAVE8_OUTPUT[i]);
+        assert_eq!(wave.output(None), data::wave_output::RESID_WAVE8_OUTPUT[i]);
     }
 }
 
@@ -98,7 +98,7 @@ fn waveform_delta_1() {
     for i in 0..500 {
         wave.clock_delta(25);
         assert_eq!(
-            wave.output(),
+            wave.output(None),
             data::wave_delta_output::RESID_WAVE1_OUTPUT[i]
         );
     }
@@ -111,7 +111,7 @@ fn waveform_delta_2() {
     for i in 0..500 {
         wave.clock_delta(25);
         assert_eq!(
-            wave.output(),
+            wave.output(None),
             data::wave_delta_output::RESID_WAVE2_OUTPUT[i]
         );
     }
@@ -124,7 +124,7 @@ fn waveform_delta_3() {
     for i in 0..500 {
         wave.clock_delta(25);
         assert_eq!(
-            wave.output(),
+            wave.output(None),
             data::wave_delta_output::RESID_WAVE3_OUTPUT[i]
         );
     }
@@ -137,7 +137,7 @@ fn waveform_delta_4() {
     for i in 0..1500 {
         wave.clock_delta(25);
         assert_eq!(
-            wave.output(),
+            wave.output(None),
             data::wave_delta_output::RESID_WAVE4_OUTPUT[i]
         );
     }
@@ -150,7 +150,7 @@ fn waveform_delta_5() {
     for i in 0..1500 {
         wave.clock_delta(25);
         assert_eq!(
-            wave.output(),
+            wave.output(None),
             data::wave_delta_output::RESID_WAVE5_OUTPUT[i]
         );
     }
@@ -163,7 +163,7 @@ fn waveform_delta_6() {
     for i in 0..1500 {
         wave.clock_delta(25);
         assert_eq!(
-            wave.output(),
+            wave.output(None),
             data::wave_delta_output::RESID_WAVE6_OUTPUT[i]
         );
     }
@@ -176,7 +176,7 @@ fn waveform_delta_7() {
     for i in 0..1500 {
         wave.clock_delta(25);
         assert_eq!(
-            wave.output(),
+            wave.output(None),
             data::wave_delta_output::RESID_WAVE7_OUTPUT[i]
         );
     }
@@ -189,7 +189,7 @@ fn waveform_delta_8() {
     for i in 0..1500 {
         wave.clock_delta(25);
         assert_eq!(
-            wave.output(),
+            wave.output(None),
             data::wave_delta_output::RESID_WAVE8_OUTPUT[i]
         );
     }


### PR DESCRIPTION
This PR eliminates Rc and RefCell use, so Send and Clone can be derived for Sid.

- Send allows Sid to be used in callbacks (like with CPAL) and in async Rust (between awaits).
- Clone may be useful for emulators that implement snapshots and for audio players to support seeking back by restoring a previous state.

Also, interior mutability [should be avoided](https://doc.rust-lang.org/std/cell/index.html#when-to-choose-interior-mutability) anyway.