### PR TITLE
Avoid allocations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ name = "resid"
 
 [features]
 default = ["std"]
-std = []
+std = ["alloc"]
+alloc = []
 
 [dependencies]
 bit_field = "0.10"

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -526,10 +526,8 @@ impl Filter {
                 y: pt.1 as f64,
             })
             .collect::<Vec<spline::Point>>();
-        let mut plotter = spline::PointPlotter::new(2048);
+        let mut plotter = spline::PointPlotter::new(&mut self.f0[..2048]);
         spline::interpolate(&points, &mut plotter, 1.0);
-        let output = plotter.output();
-        self.f0[..2048].clone_from_slice(&output[..2048]);
     }
 
     fn set_q(&mut self) {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -5,7 +5,6 @@
 
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::cast_lossless))]
 
-use alloc::vec::Vec;
 use core::f64;
 
 use super::spline;
@@ -518,16 +517,8 @@ impl Filter {
     }
 
     fn set_f0(&mut self) {
-        let points = self
-            .f0_points
-            .iter()
-            .map(|&pt| spline::Point {
-                x: pt.0 as f64,
-                y: pt.1 as f64,
-            })
-            .collect::<Vec<spline::Point>>();
         let mut plotter = spline::PointPlotter::new(&mut self.f0[..2048]);
-        spline::interpolate(&points, &mut plotter, 1.0);
+        spline::interpolate(self.f0_points, &mut plotter, 1.0);
     }
 
     fn set_q(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,9 @@
 
 #![no_std]
 
-#[cfg(not(feature = "std"))]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 extern crate alloc;
-#[cfg(feature = "std")]
+#[cfg(all(feature = "alloc", feature = "std"))]
 extern crate std as alloc;
 
 mod data;

--- a/src/spline.rs
+++ b/src/spline.rs
@@ -105,6 +105,15 @@ pub struct Point {
     pub y: f64,
 }
 
+impl From<(i32, i32)> for Point {
+    fn from((x, y): (i32, i32)) -> Point {
+        Point {
+            x: x as f64,
+            y: y as f64,
+        }
+    }
+}
+
 pub struct PointPlotter<'a> {
     output: &'a mut [i32],
 }
@@ -193,14 +202,14 @@ fn interpolate_forward_difference(
 /// desirable, the end points can simply be repeated to ensure interpolation.
 /// Note also that points of non-differentiability and discontinuity can be
 /// introduced by repeating points.
-pub fn interpolate(points: &[Point], plotter: &mut PointPlotter, res: f64) {
+pub fn interpolate<P: Into<Point> + Copy>(points: &[P], plotter: &mut PointPlotter, res: f64) {
     let last_index = points.len() - 4;
     let mut i = 0;
     while i <= last_index {
-        let p0 = points[i];
-        let p1 = points[i + 1];
-        let p2 = points[i + 2];
-        let p3 = points[i + 3];
+        let p0 = points[i].into();
+        let p1 = points[i + 1].into();
+        let p2 = points[i + 2].into();
+        let p3 = points[i + 3].into();
         // p1 and p2 equal; single point.
         if p1.x != p2.x {
             let k1;

--- a/src/spline.rs
+++ b/src/spline.rs
@@ -99,28 +99,19 @@
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::float_cmp))]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::too_many_arguments))]
 
-use alloc::vec;
-use alloc::vec::Vec;
-
 #[derive(Clone, Copy, PartialEq)]
 pub struct Point {
     pub x: f64,
     pub y: f64,
 }
 
-pub struct PointPlotter {
-    output: Vec<i32>,
+pub struct PointPlotter<'a> {
+    output: &'a mut [i32],
 }
 
-impl PointPlotter {
-    pub fn new(capacity: usize) -> Self {
-        PointPlotter {
-            output: vec![0; capacity],
-        }
-    }
-
-    pub fn output(&self) -> &Vec<i32> {
-        &self.output
+impl<'a> PointPlotter<'a> {
+    pub fn new(output: &'a mut [i32]) -> Self {
+        PointPlotter { output }
     }
 
     pub fn plot(&mut self, x: f64, y: f64) {

--- a/tests/spline_test.rs
+++ b/tests/spline_test.rs
@@ -46,12 +46,8 @@ fn set_f0(f0: &mut [i32; 2048]) {
             y: pt.1 as f64,
         })
         .collect::<Vec<spline::Point>>();
-    let mut plotter = spline::PointPlotter::new(2048);
+    let mut plotter = spline::PointPlotter::new(f0);
     spline::interpolate(&points, &mut plotter, 1.0);
-    let output = plotter.output();
-    for i in 0..2048 {
-        f0[i] = output[i];
-    }
 }
 
 #[test]


### PR DESCRIPTION
This change simplifies the code and should improve performance by avoiding unnecessary allocations and copying. Also, the alloc feature (enabled by default) is added, so resid-rs can be used completely without heap allocation (with FIR disabled).